### PR TITLE
[Edit] srcdir and destdir reference syntax

### DIFF
--- a/minibaseLab1/build.xml
+++ b/minibaseLab1/build.xml
@@ -40,7 +40,7 @@
         <sequential>
             <mkdir dir="@{destdir}"/>
             <!-- avoids needing ant clean when changing interfaces -->
-            <depend srcdir="${srcdir}" destdir="${destdir}" cache="${depcache}"/>
+            <depend srcdir="@{srcdir}" destdir="@{destdir}" cache="${depcache}"/>
             <javac srcdir="@{srcdir}" destdir="@{destdir}" includeAntRuntime="no"
                     debug="${compile.debug}" source="${sourceversion}">
                 <compilerarg value="-Xlint:unchecked" />


### PR DESCRIPTION
modified srcdir & destdir referencing to solve srcdir attribute must be non-empty error

https://stackoverflow.com/questions/49104089/ant-srcdir-attribute-must-be-non-empty